### PR TITLE
removes a warning 

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pod/Classes/DownPicker.m
+++ b/Pod/Classes/DownPicker.m
@@ -277,7 +277,7 @@
 
 -(void) setValueAtIndex:(NSInteger)index
 {
-    if (index >= 0) [self pickerView:nil didSelectRow:index inComponent:0];
+    if (index >= 0) [self pickerView:pickerView didSelectRow:index inComponent:0];
     else [self setText:nil];
 }
 


### PR DESCRIPTION
removes a warning that occurs under XCode 8.3.1 regarding using a nil value as a non-nil required argument